### PR TITLE
Remove -connect postfix from all resurces created by the Cluster

### DIFF
--- a/config/crd/bases/kafka-connect.b1zzu.net_clusters.yaml
+++ b/config/crd/bases/kafka-connect.b1zzu.net_clusters.yaml
@@ -966,7 +966,7 @@ spec:
                   the Deployment
                 type: object
               image:
-                default: docker.io/apache/kafka:4.2.0
+                default: docker.io/apache/kafka:4.3.0
                 description: Image used to deploy Kafka Connect, it should be based
                   on docker.io/apache/kafka
                 type: string

--- a/internal/controller/cluster_controller_test.go
+++ b/internal/controller/cluster_controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Cluster Controller", func() {
 
 			// Service should not exist yet (reconciliation stopped after condition init)
 			svc := &corev1.Service{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, svc)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, svc)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 	})
@@ -170,21 +170,21 @@ var _ = Describe("Cluster Controller", func() {
 
 			By("checking the Service")
 			svc := &corev1.Service{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, svc)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, svc)).To(Succeed())
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(int32(8083)))
 
 			By("checking the NetworkPolicy")
 			np := &netv1.NetworkPolicy{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, np)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, np)).To(Succeed())
 
 			By("checking the ServiceAccount")
 			sa := &corev1.ServiceAccount{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, sa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, sa)).To(Succeed())
 
 			By("checking the ConfigMap")
 			cm := &corev1.ConfigMap{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect-config", Namespace: "default"}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-config", Namespace: "default"}, cm)).To(Succeed())
 			Expect(cm.Data).To(HaveKey("connect.properties"))
 			Expect(cm.Data["connect.properties"]).To(ContainSubstring("bootstrap.servers"))
 			Expect(cm.Data).To(HaveKey("connect-log4j2.properties"))
@@ -192,7 +192,7 @@ var _ = Describe("Cluster Controller", func() {
 
 			By("checking the Deployment")
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, dep)).To(Succeed())
 
 			By("checking the Cluster status configHash")
 			cluster := &kafkaconnectv1alpha1.Cluster{}
@@ -239,7 +239,7 @@ var _ = Describe("Cluster Controller", func() {
 
 			// Deployment should not have been created
 			dep := &appsv1.Deployment{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, dep)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, dep)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 	})
@@ -274,24 +274,24 @@ var _ = Describe("Cluster Controller", func() {
 
 			By("checking that NetworkPolicy does NOT exist")
 			np := &netv1.NetworkPolicy{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, np)
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, np)
 			Expect(errors.IsNotFound(err)).To(BeTrue())
 
 			By("checking the Service exists")
 			svc := &corev1.Service{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, svc)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, svc)).To(Succeed())
 
 			By("checking the ServiceAccount exists")
 			sa := &corev1.ServiceAccount{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, sa)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, sa)).To(Succeed())
 
 			By("checking the ConfigMap exists")
 			cm := &corev1.ConfigMap{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect-config", Namespace: "default"}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-config", Namespace: "default"}, cm)).To(Succeed())
 
 			By("checking the Deployment exists")
 			dep := &appsv1.Deployment{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name + "-connect", Namespace: "default"}, dep)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: "default"}, dep)).To(Succeed())
 		})
 	})
 

--- a/internal/controller/cluster_resources.go
+++ b/internal/controller/cluster_resources.go
@@ -207,7 +207,7 @@ func deploymentForCluster(cluster *kcv1alpha1.Cluster) *appsv1ac.DeploymentApply
 		replicas = *cluster.Spec.Replicas
 	}
 
-	name := fmt.Sprintf("%s-connect", cluster.Name)
+	name := cluster.Name
 
 	volumes := append([]*corev1ac.VolumeApplyConfiguration{
 		corev1ac.Volume().
@@ -396,7 +396,7 @@ func kafkaConnectConfigsForCluster(cluster *kcv1alpha1.Cluster) (map[string]stri
 }
 
 func configMapNameForCluster(cluster *kcv1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-connect-config", cluster.Name)
+	return fmt.Sprintf("%s-config", cluster.Name)
 }
 
 func configMapForCluster(cluster *kcv1alpha1.Cluster) (*corev1ac.ConfigMapApplyConfiguration, error) {
@@ -422,7 +422,7 @@ func configMapForCluster(cluster *kcv1alpha1.Cluster) (*corev1ac.ConfigMapApplyC
 func serviceForCluster(cluster *kcv1alpha1.Cluster) *corev1ac.ServiceApplyConfiguration {
 	labels := selectorLabelsForCluster(cluster)
 
-	name := fmt.Sprintf("%s-connect", cluster.Name)
+	name := cluster.Name
 
 	serviceAnnotations := cluster.Spec.ServiceAnnotations
 
@@ -448,7 +448,7 @@ func networkPolicyForCluster(cluster *kcv1alpha1.Cluster, operatorNamespace stri
 		"kubernetes.io/metadata.name": operatorNamespace,
 	}
 
-	name := fmt.Sprintf("%s-connect", cluster.Name)
+	name := cluster.Name
 
 	ingressRules := []*netv1ac.NetworkPolicyIngressRuleApplyConfiguration{
 		// Rule 1: Allow operator access
@@ -496,7 +496,7 @@ func networkPolicyForCluster(cluster *kcv1alpha1.Cluster, operatorNamespace stri
 }
 
 func serviceAccountNameForCluster(cluster *kcv1alpha1.Cluster) string {
-	return fmt.Sprintf("%s-connect", cluster.Name)
+	return cluster.Name
 }
 
 func serviceAccountForCluster(cluster *kcv1alpha1.Cluster) *corev1ac.ServiceAccountApplyConfiguration {
@@ -517,7 +517,7 @@ func podDisruptionBudgetForCluster(cluster *kcv1alpha1.Cluster) *policyv1ac.PodD
 		maxUnavailable = *cluster.Spec.MaxUnavailable
 	}
 
-	name := fmt.Sprintf("%s-connect", cluster.Name)
+	name := cluster.Name
 
 	return policyv1ac.PodDisruptionBudget(name, cluster.Namespace).
 		WithOwnerReferences(ownerReferenceForCluster(cluster)).

--- a/internal/controller/cluster_resources_test.go
+++ b/internal/controller/cluster_resources_test.go
@@ -333,7 +333,7 @@ var _ = Describe("Cluster Resources", func() {
 			dep := deploymentForCluster(cluster)
 
 			Expect(dep.Spec.Template.Spec.ServiceAccountName).NotTo(BeNil())
-			Expect(*dep.Spec.Template.Spec.ServiceAccountName).To(Equal("my-cluster-connect"))
+			Expect(*dep.Spec.Template.Spec.ServiceAccountName).To(Equal(testClusterName))
 		})
 
 		It("should always set KAFKA_LOG4J_OPTS pointing to the custom Log4j2 config", func() {
@@ -972,7 +972,7 @@ var _ = Describe("Cluster Resources", func() {
 			}
 			sa := serviceAccountForCluster(cluster)
 
-			Expect(*sa.Name).To(Equal("my-cluster-connect"))
+			Expect(*sa.Name).To(Equal(testClusterName))
 			Expect(*sa.Namespace).To(Equal("default"))
 		})
 
@@ -1284,7 +1284,7 @@ var _ = Describe("Cluster Resources", func() {
 			}
 			pdb := podDisruptionBudgetForCluster(cluster)
 
-			Expect(*pdb.Name).To(Equal("my-cluster-connect"))
+			Expect(*pdb.Name).To(Equal(testClusterName))
 			Expect(*pdb.Namespace).To(Equal("default"))
 		})
 

--- a/internal/controller/connector_controller.go
+++ b/internal/controller/connector_controller.go
@@ -750,7 +750,7 @@ func (r *ConnectorReconciler) updateStatusCondition(
 // NewDefaultKafkaConnectClientFunc returns a factory that creates Kafka Connect
 // clients using the in-cluster service endpoint.
 func NewDefaultKafkaConnectClientFunc(connector *kcv1alpha1.Connector) *kafkaconnect.Client {
-	endpoint := fmt.Sprintf("http://%s-connect.%s:8083", connector.Spec.ClusterRef.Name, connector.Namespace)
+	endpoint := fmt.Sprintf("http://%s.%s:8083", connector.Spec.ClusterRef.Name, connector.Namespace)
 	return kafkaconnect.NewClient(endpoint)
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 
 			By("Fetching Kafka Connect pod logs")
-			cmd = exec.Command("kubectl", "logs", "deployment/my-cluster-connect",
+			cmd = exec.Command("kubectl", "logs", "deployment/my-cluster",
 				"-n", "default", "--tail=100")
 			connectLogs, err := utils.Run(cmd)
 			if err == nil {
@@ -363,7 +363,7 @@ var _ = Describe("Manager", Ordered, func() {
 		It("should deploy Connect and reach Connector Running state", func() {
 			By("waiting for the Connect deployment to be available")
 			verifyConnectDeployment := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "deployment", "my-cluster-connect",
+				cmd := exec.Command("kubectl", "get", "deployment", "my-cluster",
 					"-n", "default",
 					"-o", "jsonpath={.status.conditions[?(@.type=='Available')].status}")
 				output, err := utils.Run(cmd)


### PR DESCRIPTION
**Note:**

This is a major change and will require manual clean-up after installing:

```
kubectl delete deployments <name>-connect
kubectl delete configmaps <name>-connect
kubectl delete serviceaccounts <name>-connect
kubectl delete services <name>-connect
kubectl delete networkpolicies.networking.k8s.io <name>-connect
kubectl delete poddisruptionbudgets.policy <name>-connect
```